### PR TITLE
Fix invalid Rust identifiers generated from symbol names

### DIFF
--- a/gcrecomp-core/src/recompiler/codegen/mod.rs
+++ b/gcrecomp-core/src/recompiler/codegen/mod.rs
@@ -1209,10 +1209,23 @@ impl CodeGenerator {
     }
 
     pub fn sanitize_identifier(&self, name: &str) -> String {
-        name.replace([' ', '-', '.'], "_")
+        let mut identifier: String = name
+            .replace([' ', '-', '.'], "_")
             .chars()
             .filter(|c| c.is_alphanumeric() || *c == '_')
-            .collect()
+            .collect();
+
+        if identifier.is_empty() {
+            identifier.push_str("function");
+        } else if identifier
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_numeric())
+        {
+            identifier.insert_str(0, "function_");
+        }
+
+        identifier
     }
 
     fn indent(&self) -> String {

--- a/gcrecomp-core/tests/codegen_test.rs
+++ b/gcrecomp-core/tests/codegen_test.rs
@@ -168,6 +168,11 @@ fn test_mtctr_sets_ctr() {
 fn test_sanitize_identifier() {
     let codegen = CodeGenerator::new();
 
+    assert_eq!(codegen.sanitize_identifier(""), "function");
+    assert_eq!(
+        codegen.sanitize_identifier("123_example"),
+        "function_123_example"
+    );
     assert_eq!(
         codegen.sanitize_identifier("test_function"),
         "test_function"
@@ -184,4 +189,5 @@ fn test_sanitize_identifier() {
         codegen.sanitize_identifier("test function"),
         "test_function"
     );
+    assert_eq!(codegen.sanitize_identifier("@@@"), "function");
 }


### PR DESCRIPTION
## Description

Generated function names can fail to compile when a source symbol becomes empty after sanitization or begins with a digit. This change gives empty results a neutral fallback and prefixes digit-leading results so the generated Rust identifier has a valid start.

Existing valid identifiers and the current punctuation normalization remain unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test addition/update

## Related Issues

No linked issue.

## Changes Made

- Return `function` when sanitization would otherwise produce an empty string.
- Prefix sanitized identifiers that begin with a number with `function_`.
- Add focused regression coverage for empty input, leading digits, punctuation, punctuation-only input, and an already-valid identifier.

## Testing

- [x] `cargo fmt --all -- --check` — passed locally and on Ubuntu stable.
- [x] `cargo test -p gcrecomp-core` — passed on Ubuntu stable: 23 tests across four test binaries, 0 failed.
- [x] `cargo clippy -p gcrecomp-core --all-targets --all-features -- -D warnings` — passed on Ubuntu stable.
- [x] `git diff --check upstream/main...HEAD` — passed locally.
- [x] Complete diff reviewed against `upstream/main`; only the sanitizer and focused codegen tests are changed.

Remote validation: [focused CI run](https://github.com/KakarottoCake/EclipseRecompiled/actions/runs/30432902580). Upstream's own CI is waiting for the repository's first-time-contributor workflow approval; GitHub reports `action_required`, not a test failure. Local Rust test/clippy execution was blocked because this Windows shell resolves DevkitPro's Unix `link.exe` instead of the Microsoft linker, so the package checks were run in the clean Ubuntu stable workflow above.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (not needed; no public API change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (passed in the clean CI environment; local linker limitation documented above)
- [x] Any dependent changes have been merged and published (none)
- [x] I have read the [EULA](EULA.md) and [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My contribution complies with clean-room reverse engineering principles
- [x] I have not included any proprietary Nintendo code, SDKs, or copyrighted assets

## Additional Notes

The fixtures are entirely synthetic and the branch is based directly on the current `upstream/main` (`d380537`).